### PR TITLE
Fix og:image parse error

### DIFF
--- a/templates/bootstrappers_layout.html.erb.erb
+++ b/templates/bootstrappers_layout.html.erb.erb
@@ -13,7 +13,7 @@
 
   <meta property="og:title"       content="<%%= page_title ||  SeoHelper.configuration.site_name %>"/>
   <meta property="og:description" content="<%%= page_description || SeoHelper.configuration.default_page_description %>"/>
-  <meta property="og:image:url"   content="<%%= page_image ||  SeoHelper.configuration.default_page_image %>"/>
+  <meta property="og:image"   content="<%%= page_image ||  SeoHelper.configuration.default_page_image %>"/>
 
 </head>
 


### PR DESCRIPTION
Since Facebook cannot parse og:image:url correctly, resulting open graph image as “unspecified.”
