### PR TITLE
一些新版的改動

### DIFF
--- a/lib/bootstrappers/app_builder.rb
+++ b/lib/bootstrappers/app_builder.rb
@@ -14,7 +14,7 @@ module Bootstrappers
     end
 
     def add_devise_gem
-      inject_into_file 'Gemfile', "\ngem 'devise', '3.0.2'",
+      inject_into_file 'Gemfile', "\ngem 'devise', '3.2.4'",
       :after => /gem 'jquery-rails'/
     end
 
@@ -50,7 +50,7 @@ module Bootstrappers
     end
 
     def replace_email_sender_for_devise
-      replace_in_file 'config/initializers/devise.rb', /config\.mailer_sender = \".+\"/ , "config.mailer_sender = Setting.email_sender"
+      replace_in_file 'config/initializers/devise.rb', /config\.mailer_sender = \'.+\'/ , "config.mailer_sender = Setting.email_sender"
     end
 
     def gitignore_files
@@ -87,7 +87,7 @@ module Bootstrappers
 
 
     def remove_routes_comment_lines
-      replace_in_file 'config/routes.rb', /Application\.routes\.draw do.*end/m, "Application.routes.draw do\nend"
+      replace_in_file 'config/routes.rb', /Rails\.application\.routes\.draw do.*end/m, "Rails.application.routes.draw do\nend"
     end
 
     def use_mysql_config_template

--- a/templates/Gemfile_additions
+++ b/templates/Gemfile_additions
@@ -1,7 +1,7 @@
 gem "seo_helper", "~> 1.0.2"
 gem "open_graph_helper"
 
-gem "rmagick"
+#gem "rmagick"
 gem "carrierwave"
 gem "carrierwave-meta"
 
@@ -21,7 +21,7 @@ gem "rvm-capistrano"
 
 gem "omniauth"
 gem "omniauth-facebook"
-gem "auto-facebook", "0.4"
+gem "auto-facebook", "0.42"
 
 
 gem "whenever"


### PR DESCRIPTION
[rails 101 ,bootstrapper fixed]
Ruby 版本：ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
Rails 版本：4.1.2

一些新版的改動，今天在測試重新下載然後 bootstrapper object_name 時出了一些錯誤，順著把一些新版遇到gem問題修一修，不確定是否有改變完善，我會再試試看。
